### PR TITLE
Cap framerate to 25fps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ exports.video = function (source, target, options, callback) {
   // create target folder if needed
   mkdirp.sync(path.dirname(target))
   // always output to mp4 which is well read on the web
-  const args = ['-i', source, '-y', target, '-f', 'mp4', '-vcodec', 'libx264', '-ab', '96k']
+  const args = ['-i', source, '-r', '25', '-vsync', '2', '-y', target, '-f', 'mp4', '-vcodec', 'libx264', '-ab', '96k']
   // AVCHD/MTS videos need a full-frame export to avoid interlacing artefacts
   if (path.extname(source).toLowerCase() === '.mts') {
     args.push('-vf', 'yadif=1', '-qscale:v', '4')


### PR DESCRIPTION
Some (minute-long) slow-motion videos I converted took hours to convert and ended up much larger than the source videos. Apparently ffmpeg created 500fps videos. Naturally, this doesn't make much sense.

This change instructs ffmpeg to set the output framerate to 25fps but will never duplicate frames, only drop them - effectively capping the output framerate at 25fps.