### PR TITLE
Enable faststart for videos

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ exports.video = function (source, target, options, callback) {
   // create target folder if needed
   mkdirp.sync(path.dirname(target))
   // always output to mp4 which is well read on the web
-  const args = ['-i', source, '-r', '25', '-vsync', '2', '-y', target, '-f', 'mp4', '-vcodec', 'libx264', '-ab', '96k']
+  const args = ['-i', source, '-r', '25', '-vsync', '2', '-movflags', '+faststart', '-y', target, '-f', 'mp4', '-vcodec', 'libx264', '-ab', '96k']
   // AVCHD/MTS videos need a full-frame export to avoid interlacing artefacts
   if (path.extname(source).toLowerCase() === '.mts') {
     args.push('-vf', 'yadif=1', '-qscale:v', '4')


### PR DESCRIPTION
This just adds the option mentioned in #4. There are no tests on ffmpeg version because I'm not sure how to properly do those, but maybe it's overkill anyway. The feature [appears to have been added in version 1.0](https://github.com/FFmpeg/FFmpeg/commit/a714150827c70f8baf2ec42dfecd9363c17e803d), release on 2012-09-28.