### PR TITLE
feat: video framerate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The default export video FPS is 25. You can specify an explicit FPS by adding a 
 
 ```js
 opts = { framerate: 60 }
-opts = { framerate: 'preserve' }   // preserve the original source video's FPS
+opts = { framerate: 0 }   // preserve the original source video's FPS
 ```
 
 ##### Conversion progress

--- a/README.md
+++ b/README.md
@@ -211,6 +211,15 @@ The default value is `none`
 opts = { video-hwaccel: 'vaapi' }
 ```
 
+##### Video FPS
+
+The default export video FPS is 25. You can specify an explicit FPS by adding a `framerate` option:
+
+```js
+opts = { framerate: 60 }
+opts = { framerate: 'preserve' }   // preserve the original source video's FPS
+```
+
 ##### Conversion progress
 
 The `.video()` call returns an [EventEmitter](https://nodejs.org/api/events.html)

--- a/lib/video/ffargs.js
+++ b/lib/video/ffargs.js
@@ -23,7 +23,7 @@ exports.prepare = function (source, target, options) {
   args.push('-i', source)
 
   // output framerate
-  if (options.framerate !== 'preserve') {
+  if (options.framerate !== 0) {
     args.push('-r', options.framerate || DEFAULT_VIDEO_FPS)
   }
 

--- a/lib/video/ffargs.js
+++ b/lib/video/ffargs.js
@@ -23,7 +23,9 @@ exports.prepare = function (source, target, options) {
   args.push('-i', source)
 
   // output framerate
-  args.push('-r', DEFAULT_VIDEO_FPS)
+  if (options.framerate !== 'preserve') {
+    args.push('-r', options.framerate || DEFAULT_VIDEO_FPS)
+  }
 
   // misc options
   args.push('-vsync', '2', '-movflags', '+faststart')

--- a/test/unit/ffargs.test.js
+++ b/test/unit/ffargs.test.js
@@ -29,4 +29,24 @@ describe('ffargs', () => {
     const str = args.join(' ')
     should(str).match(/-vf yadif=1/)
   })
+
+  describe('framerate', () => {
+    it('sets to a default value if not specified', () => {
+      const args = ffargs.prepare('source.mts', 'target.mp4', {})
+      const str = args.join(' ')
+      should(str).match(/-r 25/)
+    })
+
+    it('can specify a value', () => {
+      const args = ffargs.prepare('source.mts', 'target.mp4', { framerate: 60 })
+      const str = args.join(' ')
+      should(str).match(/-r 60/)
+    })
+
+    it('keeps the source framerate if set to 0', () => {
+      const args = ffargs.prepare('source.mts', 'target.mp4', { framerate: 0 })
+      const str = args.join(' ')
+      should(str).not.match(/-r/)
+    })
+  })
 })


### PR DESCRIPTION
### Motivation

This change is ultimately for `thumbsup` to expose as an option. I want the ability to specify/preserve the framerates of videos that are being resized/converted for web-friendliness.


- [x] ran `npm test`
- [x] tested with `thumbsup`
