### PR TITLE
Added vaapi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ This is not compatible with the `quality` option.
 opts = { bitrate: '1200k' }
 ```
 
+##### HW acceleration
+
+Enable VAAPI HW accleration if supported on your platform (typically Intel/AMD chipsets.) 
+Requires intel-media-driver package to enable.
+This is not compatiable with the `quality` option and requires a `bitrate` setting.
+The default value is `none`
+
+```js
+// values 'vaapi' or 'none'
+opts = { video-hwaccel: 'vaapi' }
+```
+
 ##### Conversion progress
 
 The `.video()` call returns an [EventEmitter](https://nodejs.org/api/events.html)

--- a/lib/video/ffargs.js
+++ b/lib/video/ffargs.js
@@ -13,21 +13,21 @@ const ENCODER_CRF = {
 exports.prepare = function (source, target, options) {
   // output framerate
   const args = ['-y']
-  
+
   // IF VAAPI acceleration needs to go before -i input files
   if ((options.bitrate) && (options.hwaccel === 'vaapi')) {
-    args.push('-hwaccel_device', '/dev/dri/renderD128', '-hwaccel', 'vaapi', '-hwaccel_output_format', 'vaapi');
+    args.push('-hwaccel_device', '/dev/dri/renderD128', '-hwaccel', 'vaapi', '-hwaccel_output_format', 'vaapi')
   }
 
   // source file
   args.push('-i', source)
-  
+
   // output framerate
   args.push('-r', DEFAULT_VIDEO_FPS)
 
   // misc options
   args.push('-vsync', '2', '-movflags', '+faststart')
-  
+
   // audio bitrate
   args.push('-ab', DEFAULT_AUDIO_BITRATE)
 
@@ -38,8 +38,7 @@ exports.prepare = function (source, target, options) {
     args.push('-f', 'mp4')
     if ((options.bitrate) && (options.hwaccel === 'vaapi')) {
       args.push('-c:v', 'h264_vaapi') // if VAAPI available
-    }
-    else {
+    } else {
       args.push('-vcodec', 'libx264')
     }
   }
@@ -57,13 +56,12 @@ exports.prepare = function (source, target, options) {
   // AVCHD/MTS videos need a full-frame export to avoid interlacing artefacts
   if (path.extname(source).toLowerCase() === '.mts') {
     args.push('-vf', 'yadif=1')
-  }
-  else if ((options.bitrate) && (options.hwaccel === 'vaapi')) {
+  } else if ((options.bitrate) && (options.hwaccel === 'vaapi')) {
     // if VAAPI + here you to add the scaling option too ",scale_vaapi=1280:-1"
     args.push('-vf', 'format=nv12|vaapi,hwupload')
   }
 
-    // target filename
+  // target filename
   args.push(target)
 
   return args

--- a/lib/video/ffargs.js
+++ b/lib/video/ffargs.js
@@ -11,15 +11,23 @@ const ENCODER_CRF = {
 }
 
 exports.prepare = function (source, target, options) {
-  // source file
-  const args = ['-i', source]
+  // output framerate
+  const args = ['-y']
+  
+  // IF VAAPI acceleration needs to go before -i input files
+  if (options.hwaccel === 'vaapi') {
+    args.push('-hwaccel_device', '/dev/dri/renderD128', '-hwaccel', 'vaapi', '-hwaccel_output_format', 'vaapi');
+  }
 
+  // source file
+  args.push('-i', source)
+  
   // output framerate
   args.push('-r', DEFAULT_VIDEO_FPS)
 
   // misc options
   args.push('-vsync', '2', '-movflags', '+faststart')
-
+  
   // audio bitrate
   args.push('-ab', DEFAULT_AUDIO_BITRATE)
 
@@ -27,7 +35,13 @@ exports.prepare = function (source, target, options) {
   if (options.format === 'webm') {
     args.push('-f', 'webm', '-vcodec', 'libvpx-vp9', '-strict', '-2')
   } else {
-    args.push('-f', 'mp4', '-vcodec', 'libx264')
+    args.push('-f', 'mp4')
+    if (options.hwaccel === 'vaapi') {
+      args.push('-c:v', 'h264_vaapi') // if VAAPI available
+    }
+    else {
+      args.push('-vcodec', 'libx264')
+    }
   }
 
   // set average video bitrate or perceptual quality
@@ -44,9 +58,13 @@ exports.prepare = function (source, target, options) {
   if (path.extname(source).toLowerCase() === '.mts') {
     args.push('-vf', 'yadif=1')
   }
+  else if (options.hwaccel === 'vaapi') {
+    // if VAAPI + here you to add the scaling option too ",scale_vaapi=1280:-1"
+    args.push('-vf', 'format=nv12|vaapi,hwupload')
+  }
 
-  // target filename
-  args.push('-y', target)
+    // target filename
+  args.push(target)
 
   return args
 }

--- a/lib/video/ffargs.js
+++ b/lib/video/ffargs.js
@@ -15,7 +15,7 @@ exports.prepare = function (source, target, options) {
   const args = ['-y']
   
   // IF VAAPI acceleration needs to go before -i input files
-  if (options.hwaccel === 'vaapi') {
+  if ((options.bitrate) && (options.hwaccel === 'vaapi')) {
     args.push('-hwaccel_device', '/dev/dri/renderD128', '-hwaccel', 'vaapi', '-hwaccel_output_format', 'vaapi');
   }
 
@@ -36,7 +36,7 @@ exports.prepare = function (source, target, options) {
     args.push('-f', 'webm', '-vcodec', 'libvpx-vp9', '-strict', '-2')
   } else {
     args.push('-f', 'mp4')
-    if (options.hwaccel === 'vaapi') {
+    if ((options.bitrate) && (options.hwaccel === 'vaapi')) {
       args.push('-c:v', 'h264_vaapi') // if VAAPI available
     }
     else {
@@ -58,7 +58,7 @@ exports.prepare = function (source, target, options) {
   if (path.extname(source).toLowerCase() === '.mts') {
     args.push('-vf', 'yadif=1')
   }
-  else if (options.hwaccel === 'vaapi') {
+  else if ((options.bitrate) && (options.hwaccel === 'vaapi')) {
     // if VAAPI + here you to add the scaling option too ",scale_vaapi=1280:-1"
     args.push('-vf', 'format=nv12|vaapi,hwupload')
   }


### PR DESCRIPTION
Hi -

I decided to take a crack at adding vaapi support for the video re-encoding.   It does significantly improve the performance by 10x on my system.  

In the docker instance, it requires the intel-media-driver package and an alpine linux version >= 3.12.