### PR TITLE
Improve performance of frame extraction

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,8 @@ exports.still = function (source, target, options, callback) {
 
 function extractFrame (source, target, options, callback) {
   getSeekPoint(source, options, (_, seekPoint) => {
-    const atseek = ['-i', source, '-vframes', 1, '-ss', seekPoint, '-y', target]
+    const atseek = ['-skip_frame', 'nokey', '-i', source, '-vframes', 1, '-ss',
+      seekPoint, '-y', target]
     const fallback = ['-i', source, '-vframes', 1, '-y', target]
     ffmpeg.exec(atseek, (err) => {
       if (fs.existsSync(target)) {


### PR DESCRIPTION
With an H.265 video the CPU time consumption got reduced by ~70 %, RAM usage by ~10 %.